### PR TITLE
[GitHub-Action]: Auto-formatting based on autoyapf

### DIFF
--- a/.github/workflows/autoyapf.yml
+++ b/.github/workflows/autoyapf.yml
@@ -1,0 +1,34 @@
+name: Formatting python code
+on:
+  push:
+    branches-ignore:
+    # We don't want code modified after merge in master
+    - master
+    paths:
+    # Run action if any python-file is pushed
+    - '**.py'
+jobs:
+  autoyapf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Auto-formatting
+        id: Auto-formatting
+        uses: mritunjaysharma394/autoyapf@v2
+        with:
+          args: --style pep8 --recursive --in-place .
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "GitHub Action: Apply Pep8-formatting"
+          git push
+
+


### PR DESCRIPTION
The Action introduced is as follows:

- Every push to spack-c2sm that includes a *.py files triggers action
- All Python files (not only those contained in commit) in spack-c2sm are checked
- Action creates a new commit in same branch that brings all changes for Pep8-formatting
- Action is disabled for branch *master*, because we don't want code changes after a merge into master

The first time the action runs, all existing files are formatted. This was done in another branch.
See https://github.com/C2SM/spack-c2sm/pull/298/ for the formatting changes.

