### PR TITLE
[Icon] cleanup testing

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -708,7 +708,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             make.jobs = make_jobs
         make(*self.build_targets)
 
-    def check(self): 
+    def check(self):
         # By default "check" calls make with targets "check" and "test".
         # This testing is beyond the scope of BuildBot test at CSCS.
         # Therefore override this function, saves a lot of time too.


### PR DESCRIPTION
So far we ran BB-tests twice with `--test=root`.
See #760 for more infos

Remove obsolete `try ... except`.