### PR TITLE
Add testing dependency

### DIFF
--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -53,6 +53,7 @@ class PyIcon4py(PythonPackage):
         # check if all installed module can be imported
         super().test()
         # unit tests
+        os.environ['GT4PY_BUILD_CACHE_DIR'] = self.build_directory
 
         python('-m', 'pytest', '-v', '-s', '-n', 'auto', '-m',
                'not slow_tests')

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -161,7 +161,7 @@ class PythonPipBuilder(PythonPipBuilder):
             build_dirs = [
                 'tools', 'model/atmosphere/dycore',
                 'model/atmosphere/diffusion', 'model/atmosphere/advection',
-                'model/common/'
+                'model/common/', 'model/testing/'
             ]
 
         for dir in build_dirs:

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -47,14 +47,20 @@ class PyIcon4py(PythonPackage):
 
     # cmake in unit-tests needs this path
     def setup_build_environment(self, env):
+        """Wrapper until spack has a real implementation of setup_test_environment()"""
+        if self.run_tests:
+            self.setup_test_environment(env)
+
         env.set("CMAKE_INCLUDE_PATH", self.spec['boost'].prefix.include)
+
+    def setup_test_environment(self, env):
+        """Configure the regression test suite like Debian's openssh-tests package"""
+        env.set("GT4PY_BUILD_CACHE_DIR", self.build_directory)
 
     def test(self):
         # check if all installed module can be imported
         super().test()
         # unit tests
-        os.environ['GT4PY_BUILD_CACHE_DIR'] = self.build_directory
-
         python('-m', 'pytest', '-v', '-s', '-n', 'auto', '-m',
                'not slow_tests')
 


### PR DESCRIPTION
spack fails in the icon4Py repo as `model/testing` is not installed